### PR TITLE
Fix base URL handling and error messages

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -8,4 +8,6 @@ NEXT_PUBLIC_LOGO_URL="/images/mbkkblb6cghvqx8b6rs.png"
 NEXT_PUBLIC_BACKGROUND_URL="/images/mbozhclr408qsid3o7j.jpg"
 
 # V2Board API Configuration
+# Set to the root domain of your V2Board API. Do not include `/api/v1` when
+# using the default request helper.
 NEXT_PUBLIC_V2BOARD_API_URL="https://api.smlz.cloud"

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -83,8 +83,8 @@ class AuthManager {
       this.setState({ isLoading: false })
 
       // ✅ 如果服务器返回了错误信息（如邮箱或密码错误）
-      if (error.response?.data?.message) {
-        return { success: false, message: error.response.data.message }
+      if (error.data?.message) {
+        return { success: false, message: error.data.message }
       }
 
       // 否则 fallback 为默认提示
@@ -110,8 +110,11 @@ class AuthManager {
         this.setState({ isLoading: false })
         return { success: false, message: response.message || "注册失败" }
       }
-    } catch (error) {
+    } catch (error: any) {
       this.setState({ isLoading: false })
+      if (error.data?.message) {
+        return { success: false, message: error.data.message }
+      }
       return { success: false, message: "网络错误，请稍后重试" }
     }
   }
@@ -127,7 +130,10 @@ class AuthManager {
       } else {
         return { success: false, message: response.message || "发送失败" }
       }
-    } catch (error) {
+    } catch (error: any) {
+      if (error.data?.message) {
+        return { success: false, message: error.data.message }
+      }
       return { success: false, message: "网络错误，请稍后重试" }
     }
   }
@@ -181,7 +187,10 @@ class AuthManager {
       } else {
         return { success: false, message: response.message || "重置失败" }
       }
-    } catch (e) {
+    } catch (e: any) {
+      if (e.data?.message) {
+        return { success: false, message: e.data.message }
+      }
       return { success: false, message: "网络错误，请稍后重试" }
     }
   }

--- a/lib/v2board-api.ts
+++ b/lib/v2board-api.ts
@@ -45,7 +45,11 @@ class V2BoardAPI {
   }
 
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<V2BoardResponse<T>> {
-    const url = `${this.baseUrl}/api/v1${endpoint}`
+    let base = this.baseUrl.replace(/\/+$/, "")
+    if (!base.endsWith("/api/v1")) {
+      base += "/api/v1"
+    }
+    const url = `${base}${endpoint}`
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- ensure API requests only append `/api/v1` when needed
- surface backend error messages from v2board API
- clarify `.env.local` about root API URL

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f578264c832a906284f2897f858a